### PR TITLE
Fix build failure by updating dependencies and TypeScript configuration

### DIFF
--- a/src/backend/analytics/package.json
+++ b/src/backend/analytics/package.json
@@ -15,8 +15,8 @@
   "dependencies": {
     "fastify": "^4.24.0",
     "@fastify/cors": "^8.5.0",
-    "fastify-helmet": "^11.1.1",
-    "fastify-rate-limit": "^9.1.0",
+    "@fastify/helmet": "^9.1.0",
+    "@fastify/rate-limit": "^9.1.0",
     "@fastify/swagger": "^8.12.0",
     "@fastify/swagger-ui": "^2.1.0",
     "pg": "^8.11.0",

--- a/src/backend/identity/package.json
+++ b/src/backend/identity/package.json
@@ -13,8 +13,8 @@
   "dependencies": {
     "fastify": "^4.24.0",
     "@fastify/cors": "^8.5.0",
-    "fastify-helmet": "^11.1.1",
-    "fastify-rate-limit": "^9.1.0",
+    "@fastify/helmet": "^9.1.0",
+    "@fastify/rate-limit": "^9.1.0",
     "@fastify/swagger": "^8.12.0",
     "@fastify/swagger-ui": "^2.1.0",
     "pg": "^8.11.0",

--- a/src/backend/package.json
+++ b/src/backend/package.json
@@ -14,9 +14,9 @@
   },
   "dependencies": {
     "fastify": "^4.24.0",
-    "fastify-cors": "^9.0.1", 
-    "fastify-helmet": "^11.1.1",
-    "fastify-rate-limit": "^9.1.0",
+    "@fastify/cors": "^8.5.0",
+    "@fastify/helmet": "^9.1.0",
+    "@fastify/rate-limit": "^9.1.0",
     "@fastify/swagger": "^8.12.0",
     "@fastify/swagger-ui": "^2.1.0",
     "pg": "^8.11.0",

--- a/src/backend/progression/package.json
+++ b/src/backend/progression/package.json
@@ -13,8 +13,8 @@
   "dependencies": {
     "fastify": "^4.24.0",
     "@fastify/cors": "^8.5.0",
-    "fastify-helmet": "^11.1.1",
-    "fastify-rate-limit": "^9.1.0",
+    "@fastify/helmet": "^9.1.0",
+    "@fastify/rate-limit": "^9.1.0",
     "@fastify/swagger": "^8.12.0",
     "@fastify/swagger-ui": "^2.1.0",
     "pg": "^8.11.0",

--- a/src/backend/tsconfig.json
+++ b/src/backend/tsconfig.json
@@ -4,13 +4,13 @@
     "lib": ["ES2020"],
     "module": "CommonJS",
     "skipLibCheck": true,
+    "composite": true,
     "strict": true,
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
     "forceConsistentCasingInFileNames": true,
     "declaration": true,
     "outDir": "./dist",
-    "rootDir": "./src",
     "resolveJsonModule": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
@@ -19,6 +19,6 @@
     "emitDecoratorMetadata": true,
     "moduleResolution": "node"
   },
-  "include": ["src/**/*.ts", "../contracts/**/*.json"],
+  "include": ["**/*.ts", "../contracts/**/*.json"],
   "exclude": ["node_modules", "dist", "**/*.test.ts"]
 }

--- a/src/client/tsconfig.json
+++ b/src/client/tsconfig.json
@@ -5,9 +5,9 @@
     "module": "ESNext",
     "skipLibCheck": true,
     "moduleResolution": "bundler",
-    "allowImportingTsExtensions": true,
     "resolveJsonModule": true,
     "isolatedModules": true,
+    "composite": true,
     "noEmit": false,
     "jsx": "preserve",
     "strict": true,
@@ -16,10 +16,9 @@
     "noFallthroughCasesInSwitch": true,
     "declaration": true,
     "outDir": "./dist",
-    "rootDir": "./src",
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true
   },
-  "include": ["src/**/*.ts"],
+  "include": ["**/*.ts"],
   "exclude": ["node_modules", "dist", "**/*.test.ts"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,6 @@
     "lib": ["ES2020", "DOM", "DOM.Iterable"],
     "module": "ESNext",
     "moduleResolution": "bundler",
-    "allowImportingTsExtensions": true,
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": false,
@@ -12,7 +11,6 @@
     "declarationMap": true,
     "sourceMap": true,
     "outDir": "./dist",
-    "rootDir": "./src",
     
     // Strict Type Checking
     "strict": true,


### PR DESCRIPTION
This commit addresses a build failure that occurred in two stages.

First, it resolves a dependency issue where `npm install` was failing because of outdated and renamed `fastify` packages. The following packages were updated in all backend services:
- `fastify-helmet` -> `@fastify/helmet`
- `fastify-cors` -> `@fastify/cors`
- `fastify-rate-limit` -> `@fastify/rate-limit`

Second, it fixes several TypeScript configuration issues that were causing the build to fail after the dependencies were resolved. The following changes were made to the `tsconfig.json` files:
- Removed `rootDir` and `allowImportingTsExtensions` from the root `tsconfig.json`.
- Added `composite: true` to the `tsconfig.json` files in `src/client` and `src/backend`.
- Corrected the `include` paths in the `tsconfig.json` files in `src/client` and `src/backend`.