### PR TITLE
Debug fighting game render error

### DIFF
--- a/src/scripts/graphics/PostProcessingManager.ts
+++ b/src/scripts/graphics/PostProcessingManager.ts
@@ -246,7 +246,7 @@ class PostProcessingManager implements ISystem {
                 magFilter: pc.FILTER_LINEAR,
                 minFilter: pc.FILTER_LINEAR
             }),
-            depthBuffer: true,
+            depth: true,
             samples: this.quality === 'ultra' ? 4 : 1
         });
         
@@ -262,7 +262,7 @@ class PostProcessingManager implements ISystem {
                 magFilter: pc.FILTER_LINEAR,
                 minFilter: pc.FILTER_LINEAR
             }),
-            depthBuffer: false
+            depth: false
         });
         
         // Blur targets (half resolution for performance)
@@ -280,7 +280,7 @@ class PostProcessingManager implements ISystem {
                 magFilter: pc.FILTER_LINEAR,
                 minFilter: pc.FILTER_LINEAR
             }),
-            depthBuffer: false
+            depth: false
         });
         
         this.renderTargets.blurVertical = new pc.RenderTarget({
@@ -294,7 +294,7 @@ class PostProcessingManager implements ISystem {
                 magFilter: pc.FILTER_LINEAR,
                 minFilter: pc.FILTER_LINEAR
             }),
-            depthBuffer: false
+            depth: false
         });
         
         // Bloom target
@@ -309,7 +309,7 @@ class PostProcessingManager implements ISystem {
                 magFilter: pc.FILTER_LINEAR,
                 minFilter: pc.FILTER_LINEAR
             }),
-            depthBuffer: false
+            depth: false
         });
         
         console.log('Post-processing render targets created');


### PR DESCRIPTION
Fixes PostFX render target initialization by using `depth` instead of `depthBuffer` in PlayCanvas `RenderTarget` options.

The `pc.RenderTarget` constructor expects a `depth: boolean` option, not `depthBuffer: boolean`, which was causing a runtime error during initialization.

---
<a href="https://cursor.com/background-agent?bcId=bc-41cd46cf-8926-4cfe-9e7a-ed098bc805b5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-41cd46cf-8926-4cfe-9e7a-ed098bc805b5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

