### PR TITLE
Debug black screen loading issue

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -137,9 +137,13 @@ async function defaultStart(canvas: HTMLCanvasElement | null): Promise<void> {
       try { Logger.error('Background initialization failed', err as any); } catch {}
     });
     LoadingOverlay.complete(true);
+    // Safety: ensure overlay is gone even if a late task starts (iOS Safari quirk)
+    try { setTimeout(() => { try { LoadingOverlay.complete(true); } catch {} }, 1200); } catch {}
   } else {
     await engine.initialize();
     LoadingOverlay.complete();
+    // Safety: in case a background task starts right after completion and blocks fade-out, force hide soon after
+    try { setTimeout(() => { try { LoadingOverlay.complete(true); } catch {} }, 1200); } catch {}
   }
 }
 


### PR DESCRIPTION
Add a safety fallback to force-hide the loading overlay to prevent it from remaining visible on iOS.

This addresses a bug where background tasks (e.g., manifest fetch) could prevent the loading overlay from disappearing on iOS, resulting in a black screen. The fallback ensures the overlay is hidden shortly after initialization.

---
<a href="https://cursor.com/background-agent?bcId=bc-61d38630-4a1a-4742-93e8-a38fd9daad70">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-61d38630-4a1a-4742-93e8-a38fd9daad70">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

