### PR TITLE
Initialize and load fighting game engine

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -70,6 +70,16 @@ async function defaultStart(canvas: HTMLCanvasElement | null): Promise<void> {
   try { (LoadingOverlay as any).enableConsoleCapture?.(); } catch {}
   try { LoadingOverlay.enableNetworkTracking(); } catch {}
   try { scheduleAutoDebugReportDownload(250); } catch {}
+  // iOS Safari and users with reduced-motion often prefer immediate UI; force-hide overlay early
+  try {
+    const ua = (typeof navigator !== 'undefined' ? navigator.userAgent : '') || '';
+    const isIOS = /iPhone|iPad|iPod/i.test(ua);
+    const prefersReducedMotion = typeof matchMedia !== 'undefined' && matchMedia('(prefers-reduced-motion: reduce)').matches;
+    if (isIOS || prefersReducedMotion) {
+      // So the boot still shows log if something goes wrong, delay a tick then force-hide soon
+      setTimeout(() => { try { LoadingOverlay.complete(true); } catch {} }, 500);
+    }
+  } catch {}
   LoadingOverlay.beginTask('prepare', 'Preparing renderer', 1);
   const targetCanvas = canvas || createCanvas();
   try {


### PR DESCRIPTION
Prevent loading overlay from lingering on iOS and for reduced-motion users by ignoring background tasks and force-hiding early.

The overlay was sometimes getting stuck on iPhones because it was waiting for non-critical background tasks (like manifest fetching or background preloads) to complete before hiding. This change ensures the overlay only considers foreground tasks for its completion logic and provides an early force-hide mechanism for iOS and reduced-motion users who expect a more immediate UI experience.

---
<a href="https://cursor.com/background-agent?bcId=bc-66ce1f46-378d-48ec-8aaa-dda727b4d0fd">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-66ce1f46-378d-48ec-8aaa-dda727b4d0fd">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

