### PR TITLE
Fix manifest json loading issue

### DIFF
--- a/tools/dev_server.ts
+++ b/tools/dev_server.ts
@@ -20,6 +20,7 @@ app.get('/assets/manifest.json', (_req, res, next) => {
   const manifestPath = path.join(publicDir, 'assets', 'manifest.json');
   if (fs.existsSync(manifestPath)) {
     res.set('Content-Type', 'application/json; charset=utf-8');
+    res.set('Cache-Control', 'no-store');
     res.send(fs.readFileSync(manifestPath, 'utf-8'));
     return;
   }
@@ -54,6 +55,7 @@ app.get('/assets/manifest.json', (_req, res, next) => {
     walk(dataDir, dataDir, '/data');
     walk(assetsDataDir, assetsDataDir, '/assets/data');
     res.set('Content-Type', 'application/json; charset=utf-8');
+    res.set('Cache-Control', 'no-store');
     res.send(JSON.stringify({ assets: entries }, null, 2));
   } catch (e) {
     next(e);

--- a/vercel.json
+++ b/vercel.json
@@ -24,6 +24,10 @@
       "headers": [ { "key": "Cache-Control", "value": "public, max-age=31536000, immutable" } ]
     },
     {
+      "source": "/assets/manifest.json",
+      "headers": [ { "key": "Cache-Control", "value": "no-store" } ]
+    },
+    {
       "source": "/assets/(.*)",
       "headers": [ { "key": "Cache-Control", "value": "public, max-age=31536000, immutable" } ]
     },


### PR DESCRIPTION
Harden manifest loading to prevent app stalls and ensure correct manifest fetching by disabling caching and improving error handling.

The application was freezing at 96% during loading because the `/assets/manifest.json` fetch was failing or returning empty/invalid content, and the loader wasn't robust enough to handle it gracefully or use the fallback. This PR addresses the problem by removing versioning from the manifest URL, adding `Cache-Control: no-store` headers, and explicitly treating empty or invalid JSON responses as failures to trigger a robust fallback.

---
<a href="https://cursor.com/background-agent?bcId=bc-d954b85c-d6ab-4476-9d81-ecfa8d7ea968">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d954b85c-d6ab-4476-9d81-ecfa8d7ea968">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

