### PR TITLE
Fix manifest loading and overlay initialization

### DIFF
--- a/src/core/GameEngine.ts
+++ b/src/core/GameEngine.ts
@@ -212,17 +212,7 @@ export class GameEngine {
       // Load manifest and then preload assets with detailed progress grouped by type
       // Background preload (non-blocking) to enhance assets progressively
       setTimeout(() => {
-        try {
-          LoadingOverlay.beginTask('manifest_bg', 'Loading manifest', 1);
-        } catch {}
-        const manifestTimeout = setTimeout(() => {
-          try { LoadingOverlay.endTask('manifest_bg', false); } catch {}
-        }, 7000);
-        this.preloader.loadManifest('/assets/manifest.json', (p, label) => {
-          try { LoadingOverlay.updateTask('manifest_bg', Math.max(0, Math.min(1, p ?? 0)), label || 'Loading manifest'); } catch {}
-        }).then(() => {
-          try { clearTimeout(manifestTimeout); } catch {}
-          try { LoadingOverlay.endTask('manifest_bg', true); } catch {}
+        this.preloader.loadManifest('/assets/manifest.json').then(() => {
           try { LoadingOverlay.beginTask('preload_bg', 'Preloading core data', 5); } catch {}
           return this.preloader.preloadAllAssets({
             groupOrder: ['json'],
@@ -243,8 +233,6 @@ export class GameEngine {
         }).then(() => {
           try { LoadingOverlay.endTask('preload_bg', true); } catch {}
         }).catch(() => {
-          try { clearTimeout(manifestTimeout); } catch {}
-          try { LoadingOverlay.endTask('manifest_bg', false); } catch {}
           try { LoadingOverlay.endTask('preload_bg', false); } catch {}
         });
       }, 0);

--- a/vercel.json
+++ b/vercel.json
@@ -3,6 +3,8 @@
   "buildCommand": "npm run build && npm run postbuild",
   "outputDirectory": "public",
   "rewrites": [
+    { "source": "/assets/(.*)", "destination": "/assets/$1" },
+    { "source": "/data/(.*)", "destination": "/data/$1" },
     { "source": "/", "destination": "/api/index" },
     { "source": "/api/manifest", "destination": "/api/manifest" },
     { "source": "/api/session", "destination": "/api/session" },


### PR DESCRIPTION
Add a fail-safe manifest loader and Vercel rewrites to prevent boot UI hangs and ensure static asset delivery.

The previous manifest loading mechanism could stall if `/assets/manifest.json` failed to load or hung, causing the boot UI to remain invisible. This PR introduces a timeout and fallback to `/api/manifest`, ensuring the boot flow continues even if the primary fetch fails. Additionally, Vercel rewrites are added to explicitly serve `/assets/*` and `/data/*` statically, preventing them from being swallowed by Next.js routing. `GameEngine`'s manifest handling is simplified as `PreloadManager` now manages the `manifest_bg` overlay task directly.

---
<a href="https://cursor.com/background-agent?bcId=bc-63f47bde-1939-4892-bba2-ccb14b99b6a3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-63f47bde-1939-4892-bba2-ccb14b99b6a3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

