### PR TITLE
feat(ui): image-based startup splash and menu

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -11,12 +11,12 @@
     <script defer src="/_vercel/speed-insights/script.js"></script>
   </head>
   <body>
-    <div id="pc-loading-overlay" style="position:fixed;inset:0;background:#000;display:flex;align-items:center;justify-content:center;flex-direction:column;color:#fff;z-index:100000;">
-      <div id="pc-loading-head" style="font:12px/1.2 monospace;color:#0f0;opacity:.85;margin-bottom:8px">== Boot sequence ==</div>
-      <div id="pc-loading-bar" style="width:60%;max-width:480px;height:8px;background:#333;border-radius:4px;overflow:hidden;">
-        <div id="pc-loading-fill" style="width:0%;height:100%;background:#0f0;transition:width 0.2s"></div>
+    <div id="pc-loading-overlay" style="position:fixed;inset:0;background:url('/assets/fighting_ui/ui/health_bars/health_bars/gold_background.png') center/cover no-repeat, #000;display:flex;align-items:center;justify-content:center;flex-direction:column;color:#fff;z-index:100000;">
+      <div id="pc-loading-head" style="display:none;font:12px/1.2 monospace;color:#0f0;opacity:.85;margin-bottom:8px">== Boot sequence ==</div>
+      <div id="pc-loading-bar" style="width:60%;max-width:480px;height:24px;background:url('/assets/fighting_ui/ui/health_bars/health_bars/gray_bar.png') center/contain no-repeat, #333;border-radius:4px;overflow:hidden;">
+        <div id="pc-loading-fill" style="width:0%;height:100%;background:url('/assets/fighting_ui/ui/health_bars/health_bars/green_bar.png') left center / contain no-repeat, #0f0;transition:width 0.2s"></div>
       </div>
-      <div id="pc-loading-text" style="margin-top:12px;font:14px/1.2 monospace;opacity:.9;color:#0f0">Loading...</div>
+      <div id="pc-loading-text" style="margin-top:12px;font:14px/1.2 system-ui,-apple-system,Segoe UI,Roboto,Ubuntu,Cantarell,Noto Sans,Helvetica Neue,Arial,sans-serif;opacity:.95;color:#fff">Loading...</div>
       <div id="pc-loading-tasks" style="margin-top:8px;width:60%;max-width:480px;font:12px/1.35 monospace;opacity:.85;color:#0f0"></div>
     </div>
     

--- a/src/core/ui/LoadingOverlay.ts
+++ b/src/core/ui/LoadingOverlay.ts
@@ -37,7 +37,8 @@ export class LoadingOverlay {
 			this.container.id = 'pc-loading-overlay';
 			this.container.style.position = 'fixed';
 			this.container.style.inset = '0';
-			this.container.style.background = '#000';
+			// Use image-based background if available (falls back to solid color)
+			this.container.style.background = "url('/assets/fighting_ui/ui/health_bars/health_bars/gold_background.png') center/cover no-repeat, #000";
 			this.container.style.display = 'flex';
 			this.container.style.alignItems = 'center';
 			this.container.style.justifyContent = 'center';
@@ -59,6 +60,8 @@ export class LoadingOverlay {
 			head.textContent = '== Boot sequence ==';
 			this.container.appendChild(head);
 		}
+		// Hide text headline to favor image-based splash. It remains in DOM for fallback.
+		try { (head.style as any).display = 'none'; } catch {}
 
 		this.fill = document.getElementById('pc-loading-fill');
 		let bar = document.getElementById('pc-loading-bar');
@@ -67,8 +70,9 @@ export class LoadingOverlay {
 			bar.id = 'pc-loading-bar';
 			bar.style.width = '60%';
 			bar.style.maxWidth = '480px';
-			bar.style.height = '8px';
-			bar.style.background = '#333';
+			bar.style.height = '24px';
+			// Image-based progress bar background; fall back to color if unavailable
+			bar.style.background = "url('/assets/fighting_ui/ui/health_bars/health_bars/gray_bar.png') center/contain no-repeat, #333";
 			bar.style.borderRadius = '4px';
 			bar.style.overflow = 'hidden';
 			this.container.appendChild(bar);
@@ -79,7 +83,8 @@ export class LoadingOverlay {
 			this.fill.id = 'pc-loading-fill';
 			this.fill.style.width = '0%';
 			this.fill.style.height = '100%';
-			this.fill.style.background = '#0f0';
+			// Image-based progress bar fill; fall back to color if unavailable
+			(this.fill.style as any).background = "url('/assets/fighting_ui/ui/health_bars/health_bars/green_bar.png') left center / contain no-repeat, #0f0";
 			(this.fill.style as any).transition = 'width 0.2s';
 			bar.appendChild(this.fill);
 		}
@@ -90,9 +95,9 @@ export class LoadingOverlay {
 			this.label.id = 'pc-loading-text';
 			this.label.textContent = 'Loading...';
 			this.label.style.marginTop = '12px';
-			(this.label.style as any).font = '14px/1.2 monospace';
-			(this.label.style as any).opacity = '.9';
-			this.label.style.color = '#0f0';
+			(this.label.style as any).font = '14px/1.2 system-ui, -apple-system, Segoe UI, Roboto, Ubuntu, Cantarell, Noto Sans, Helvetica Neue, Arial, sans-serif';
+			(this.label.style as any).opacity = '.95';
+			this.label.style.color = '#fff';
 			this.container.appendChild(this.label);
 		}
 

--- a/src/core/ui/UIManager.ts
+++ b/src/core/ui/UIManager.ts
@@ -48,11 +48,66 @@ export class UIManager {
 		if (this.menu) { this.menu.enabled = true; return; }
 		this.menu = new pc.Entity('MenuUI');
 		this.menu.addComponent('element', { type: pc.ELEMENTTYPE_GROUP, anchor: new pc.Vec4(0,0,1,1) });
-		const label = new pc.Entity('MenuLabel');
-		label.addComponent('element', { type: pc.ELEMENTTYPE_TEXT, text: 'Press Enter to Start', fontSize: 48, pivot: new pc.Vec2(0.5,0.5), anchor: new pc.Vec4(0.5,0.5,0.5,0.5) });
-		this.menu.addChild(label);
+		// Image-based background splash
+		const bg = new pc.Entity('MenuBackground');
+		bg.addComponent('element', {
+			type: pc.ELEMENTTYPE_IMAGE,
+			anchor: new pc.Vec4(0, 0, 1, 1),
+			// Use gold background if available
+			texture: null as any,
+			color: new pc.Color(0,0,0,1),
+		} as any);
+		this.menu.addChild(bg);
+		// Title/logo area (center top)
+		const title = new pc.Entity('MenuTitle');
+		title.addComponent('element', {
+			type: pc.ELEMENTTYPE_TEXT,
+			text: 'Street Fighter III',
+			fontSize: 56,
+			color: new pc.Color(1,1,1,1),
+			anchor: new pc.Vec4(0.5, 0.12, 0.5, 0.12),
+			pivot: new pc.Vec2(0.5, 0.5)
+		} as any);
+		this.menu.addChild(title);
+		// Start button styled as image-based button
+		const startButton = new pc.Entity('StartButton');
+		startButton.addComponent('element', {
+			type: pc.ELEMENTTYPE_IMAGE,
+			anchor: new pc.Vec4(0.4, 0.75, 0.6, 0.85),
+			color: new pc.Color(0.15, 0.35, 0.85, 0.95)
+		} as any);
+		startButton.addComponent('button', { imageEntity: startButton });
+		const startText = new pc.Entity('StartText');
+		startText.addComponent('element', {
+			type: pc.ELEMENTTYPE_TEXT,
+			text: 'Press Enter',
+			fontSize: 28,
+			color: new pc.Color(1,1,1,1),
+			anchor: new pc.Vec4(0,0,1,1),
+			pivot: new pc.Vec2(0.5,0.5)
+		} as any);
+		startButton.addChild(startText);
+		startButton.button!.on('click', () => {
+			try {
+				// Synthesize Enter key for existing flow
+				const ev = new KeyboardEvent('keydown', { key: 'Enter' });
+				window.dispatchEvent(ev);
+			} catch {}
+		});
+		this.menu.addChild(startButton);
 		this.root?.addChild(this.menu);
 		this.setDomVisible(false);
+		// Attempt to load textures asynchronously for background and button skin
+		void (async () => {
+			try {
+				const bgTex = await this.loadTexture('/assets/fighting_ui/ui/health_bars/health_bars/gold_background.png');
+				if ((bg as any).element) { (bg as any).element.texture = bgTex; (bg as any).element.color = new pc.Color(1,1,1,1); }
+			} catch {}
+			try {
+				const btnTex = await this.loadTexture('/assets/fighting_ui/ui/kenney_ui-pack/PNG/Blue/Default/button_rectangle_square.png');
+				if ((startButton as any).element) { (startButton as any).element.texture = btnTex; (startButton as any).element.color = new pc.Color(1,1,1,1); }
+			} catch {}
+		})();
 	}
 
 	public hideMenu(): void {


### PR DESCRIPTION
### Summary
- Switch startup/loading overlay to image-based UI (background + progress bar).
- Update menu to image-based layout with background and button skin.
- Keep text fallback for robustness.

### Files
- src/core/ui/LoadingOverlay.ts
- src/core/ui/UIManager.ts
- public/index.html

### Test plan
- Build locally and open index; confirm image splash renders and menu shows a textured start button.
- Verify Enter key and button both advance.