### PR TITLE
Prevent ui element overlap

### DIFF
--- a/demo/styles.css
+++ b/demo/styles.css
@@ -39,8 +39,7 @@ body {
 }
 
 .hud {
-  display: grid;
-  grid-template-columns: 1fr auto 1fr;
+  grid-template-columns: minmax(0, 1fr) auto minmax(0, 1fr);
   align-items: center;
   padding: var(--hud-padding);
   height: var(--hud-height);
@@ -49,25 +48,29 @@ body {
   border-bottom: 2px solid rgba(255, 255, 255, 0.1);
 }
 
-.side { display: flex; flex-direction: column; gap: 8px; }
+.side { display: flex; flex-direction: column; gap: 8px; min-width: 0; }
 .side.right { align-items: flex-end; }
 
 .name {
-  font-size: 20px;
+  font-size: clamp(14px, 2.5vw, 20px);
   letter-spacing: 1px;
   text-shadow: 0 2px 0 rgba(0,0,0,0.6);
+  max-width: 100%;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .center { display: flex; align-items: center; justify-content: center; }
 .timer {
-  font-size: 42px;
+  font-size: clamp(24px, 5vw, 42px);
   padding: 8px 16px;
   border-radius: 8px;
   background: rgba(0,0,0,0.5);
   border: 2px solid rgba(255,255,255,0.25);
 }
 
-.health-bar { width: var(--bar-width); }
+.health-bar { width: min(100%, var(--bar-width, 520px)); }
 .health-bar.right { transform: scaleX(-1); }
 
 .bar-bg {
@@ -90,6 +93,7 @@ body {
   justify-content: center;
   gap: 24px;
   padding: 16px;
+  flex-wrap: wrap;
 }
 
 .group { display: flex; gap: 8px; }
@@ -118,5 +122,22 @@ button:hover {
 
 button:active {
   filter: brightness(0.9);
+}
+
+@media (max-width: 1100px) {
+  :root { --bar-width: 420px; }
+}
+@media (max-width: 900px) {
+  .hud {
+    grid-template-columns: 1fr;
+    grid-auto-rows: auto;
+    text-align: center;
+    gap: 12px;
+    height: auto;
+  }
+  .side { align-items: center; }
+  .side.right { align-items: center; }
+  .health-bar.right { transform: none; }
+  .name { white-space: normal; }
 }
 

--- a/demo/styles.css
+++ b/demo/styles.css
@@ -39,10 +39,11 @@ body {
 }
 
 .hud {
+  display: grid;
   grid-template-columns: minmax(0, 1fr) auto minmax(0, 1fr);
   align-items: center;
   padding: var(--hud-padding);
-  height: var(--hud-height);
+  min-height: var(--hud-height);
   gap: 16px;
   background: rgba(0, 0, 0, 0.35);
   border-bottom: 2px solid rgba(255, 255, 255, 0.1);
@@ -76,7 +77,7 @@ body {
 .bar-bg {
   position: relative;
   width: 100%;
-  height: var(--bar-height);
+  height: var(--bar-height, 28px);
   background: url('/workspace/assets/fighting_ui/ui/health_bars/health_bars/gray_bar.png') left center / contain no-repeat;
 }
 


### PR DESCRIPTION
Prevent UI elements from overlapping in the demo by improving responsiveness and layout.

These changes address potential overlaps in the HUD, timer, and health bars, particularly on smaller screens, by implementing CSS Grid, flexbox adjustments, and responsive sizing for text and bars.

---
<a href="https://cursor.com/background-agent?bcId=bc-38f646f0-f474-4ad3-a554-384e843ecc6b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-38f646f0-f474-4ad3-a554-384e843ecc6b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

